### PR TITLE
Fix issue count hook name

### DIFF
--- a/docs/tutorial/github-issues.md
+++ b/docs/tutorial/github-issues.md
@@ -557,7 +557,7 @@ using React's Suspense:
 ```diff
 -import React from 'react'
 +import React, { Suspense } from 'react'
-+import { useCurrentRepoOpenIssuesCount, useCurrentRepo } from 'state'
++import { useOpenIssuesLen, useCurrentRepo } from 'state'
 
 -interface OrgProps {
 -  org: string
@@ -599,7 +599,7 @@ using React's Suspense:
 -    )
 -  }
 +function OpenIssues() {
-+  const openIssuesCount = useCurrentRepoOpenIssuesCount()
++  const openIssuesCount = useOpenIssuesLen()
 +  return (
 +    <>
 +      <span className="header__openIssues">{openIssuesCount}</span> open{' '}


### PR DESCRIPTION
Before this fix, IssuesPageHeader references useCurrentRepoOpenIssuesCount, which
is not defined in state.ts This corrects the import and reference to the function defined in
https://github.com/re-rxjs/react-rxjs-github-issues-example/blob/master/src/state.ts#L74
and also on line 318 of github-issues.md